### PR TITLE
feat(dataplane): set default Pulumi update parallelism to 4

### DIFF
--- a/docs/latest/commands/dp/bootstrap.md
+++ b/docs/latest/commands/dp/bootstrap.md
@@ -25,6 +25,9 @@ The diagram illustrates the bootstrap lifecycle triggered by `dp bootstrap`:
     - [Command Line](#command-line)
 - [Bootstrap Execution](#bootstrap-execution)
   - [Minimum RBAC Permissions](#minimum-rbac-permissions)
+- [Troubleshooting](#troubleshooting)
+  - [OOM Kill](#oom-kill)
+  - [API Server Throttling](#api-server-throttling)
 
 ## Usage
 
@@ -279,3 +282,23 @@ You can generate it yourself by running `cn dp bootstrap --show-permissions-only
 ```yaml
 --8<-- "docs/latest/assets/bootstrap-clusterrole.yaml"
 ```
+
+---
+
+## Troubleshooting
+
+### OOM Kill
+
+If the workspace pod is terminated with `OOMKilled`, increase the memory limit
+in the `Stack` resource under `spec.workspaceTemplate.spec.resources`.
+
+### API Server Throttling
+
+On some clusters the API server is downsized and can have problems handling a
+big load. For this reason the parallelism of resource operations is set to `4`
+in the `Stack` resource under `spec.updateTemplate.spec.parallel`.
+
+!!! warning "Do not set parallelism below the minimum"
+
+    `4` is the current minimum. Setting a lower value introduces a possible risk
+    of a deadlock.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,9 @@ theme:
     logo: material/console
 
 markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
   - pymdownx.snippets:
       base_path: ["."]
 

--- a/src/CodeNOW.Cli/DataPlane/DataPlaneConstants.cs
+++ b/src/CodeNOW.Cli/DataPlane/DataPlaneConstants.cs
@@ -198,6 +198,13 @@ public static class DataPlaneConstants
     /// </summary>
     public const int PulumiStateHistoryRetainCount = 5;
 
+    /// <summary>
+    /// Number of resource operations Pulumi runs in parallel during stack updates
+    /// (equivalent to <c>pulumi up --parallel &lt;n&gt;</c>). Pulumi defaults to unbounded
+    /// parallelism, which overloads the workspace pod; the data plane caps it instead.
+    /// </summary>
+    public const int PulumiUpdateParallelism = 4;
+
 
     /// <summary>
     /// App name label value applied to bootstrap-generated data plane resources.

--- a/src/CodeNOW.Cli/DataPlane/Services/Provisioning/PulumiStackManifestBuilder.cs
+++ b/src/CodeNOW.Cli/DataPlane/Services/Provisioning/PulumiStackManifestBuilder.cs
@@ -105,6 +105,13 @@ internal sealed class PulumiStackManifestBuilder
                 },
                 ["destroyOnFinalize"] = true,
                 ["retryOnUpdateConflict"] = true,
+                ["updateTemplate"] = new JsonObject
+                {
+                    ["spec"] = new JsonObject
+                    {
+                        ["parallel"] = DataPlaneConstants.PulumiUpdateParallelism
+                    }
+                },
                 ["workspaceTemplate"] = BuildPulumiWorkspaceTemplate(config, image)
             }
         };

--- a/tests/CodeNOW.Cli.Tests/DataPlane/Services/Provisioning/PulumiStackManifestBuilderTests.cs
+++ b/tests/CodeNOW.Cli.Tests/DataPlane/Services/Provisioning/PulumiStackManifestBuilderTests.cs
@@ -41,6 +41,26 @@ public class PulumiStackManifestBuilderTests
     }
 
     [Fact]
+    public void BuildStack_SetsUpdateParallelism()
+    {
+        var builder = BuildBuilder();
+        var config = new OperatorConfig
+        {
+            Environment = { Name = "dev" },
+            Kubernetes = { Namespaces = { System = { Name = "system" } } },
+            Scm = { Url = "https://git.example.com/repo" }
+        };
+
+        var stack = builder.BuildStack(config, "sa");
+        var updateSpec = stack["spec"]!.AsObject()["updateTemplate"]!.AsObject()["spec"]!.AsObject();
+
+        Assert.Equal(4, DataPlaneConstants.PulumiUpdateParallelism);
+        Assert.Equal(
+            DataPlaneConstants.PulumiUpdateParallelism,
+            updateSpec["parallel"]!.GetValue<int>());
+    }
+
+    [Fact]
     public void BuildStack_FluxcdEnabled_UsesFluxSourceAndOmitsScmFields()
     {
         var builder = BuildBuilder();


### PR DESCRIPTION
Pulumi defaults to unbounded parallelism for resource operations, which overloads the workspace pod and pressures the API server on downsized clusters. Cap it at 4 via spec.updateTemplate.spec.parallel on the Stack resource, the operator equivalent of `pulumi up --parallel <n>`.

Document OOM kill and API server throttling under a new Troubleshooting section of the bootstrap command page, and enable the MkDocs Material admonition extensions needed to render the deadlock warning callout.


Claude-Session: https://claude.ai/code/session_01UVoEULvEvBnHQW7F8rnt7k